### PR TITLE
feat: add external browser authentication support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snowflake-connector-rs"
 version = "0.6.5"
-edition = "2021"
+edition = "2024"
 authors = ["kenkoooo <kenkou.n@gmail.com>"]
 description = "A Rust client for Snowflake"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["snowflake", "database", "sql", "client"]
 
 [dependencies]
-http = "1.1"
+http = "1.3"
 reqwest = { version = "0.12", features = [
     "json",
     "gzip",
@@ -19,15 +19,29 @@ reqwest = { version = "0.12", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-uuid = { version = "1.11", features = ["v4"] }
-flate2 = "1.0"
-tokio = { version = "1.41", features = ["rt"] }
+uuid = { version = "1.17", features = ["v4"] }
+flate2 = "1.1"
+tokio = { version = "1.45", features = ["rt", "net", "time"] }
 chrono = "0.4"
 pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption"] }
 rsa = "0.9"
 sha2 = "0.10"
 base64 = "0.22"
-jsonwebtoken = "9.1"
+jsonwebtoken = "9.3"
+
+# Optional dependencies for external browser authentication
+axum = { version = "0.8", optional = true }
+tower = { version = "0.5", optional = true }
+webbrowser = { version = "1.0", optional = true }
+rand = { version = "0.9", optional = true }
+url = { version = "2.5", optional = true }
+
+[features]
+external-browser-authenticator = ["axum", "tower", "webbrowser", "rand", "url"]
 
 [dev-dependencies]
-tokio = { version = "1.41", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.45", features = ["macros", "rt-multi-thread"] }
+
+[[example]]
+name = "external_browser_auth"
+required-features = ["external-browser-authenticator"]

--- a/examples/external_browser_auth.rs
+++ b/examples/external_browser_auth.rs
@@ -36,10 +36,7 @@ async fn main() -> Result<()> {
 
             // Try a simple query
             let rows = session.query("SELECT CURRENT_USER()").await?;
-            println!(
-                "Current user: {:?}",
-                rows[0].get::<String>("CURRENT_USER()")?
-            );
+            println!("Current user: {:?}", rows[0].get::<String>("CURRENT_USER()")?);
 
             Ok(())
         }

--- a/examples/external_browser_auth.rs
+++ b/examples/external_browser_auth.rs
@@ -1,0 +1,51 @@
+use snowflake_connector_rs::{Result, SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let username = std::env::var("SNOWFLAKE_USERNAME").expect("set SNOWFLAKE_USERNAME");
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").expect("set SNOWFLAKE_ACCOUNT");
+
+    let role = std::env::var("SNOWFLAKE_ROLE").ok();
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok();
+    let database = std::env::var("SNOWFLAKE_DATABASE").ok();
+    let schema = std::env::var("SNOWFLAKE_SCHEMA").ok();
+
+    println!("Creating client with external browser authentication...");
+    println!("Account: {account}");
+    println!("Username: {username}");
+
+    let client = SnowflakeClient::new(
+        &username,
+        SnowflakeAuthMethod::ExternalBrowser,
+        SnowflakeClientConfig {
+            account,
+            warehouse,
+            database,
+            schema,
+            role,
+            timeout: None,
+        },
+    )?;
+
+    println!("Creating session...");
+    println!("A browser window should open for authentication.");
+
+    match client.create_session().await {
+        Ok(session) => {
+            println!("Session created successfully!");
+
+            // Try a simple query
+            let rows = session.query("SELECT CURRENT_USER()").await?;
+            println!(
+                "Current user: {:?}",
+                rows[0].get::<String>("CURRENT_USER()")?
+            );
+
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Failed to create session: {e:?}");
+            Err(e)
+        }
+    }
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
+chain_width = 70
+comment_width = 100
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+max_width = 100
+merge_derives = false
+struct_lit_width = 50
+use_field_init_shorthand = true
+use_small_heuristics = "Max"
+wrap_comments = true

--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -1,0 +1,179 @@
+use axum::{Router, extract::Query, response::Html, routing::get};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::{net::TcpListener, time::timeout};
+
+use crate::{Error, Result};
+
+const SSO_URL_ENDPOINT: &str = "/session/authenticator-request";
+const BROWSER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Debug, Serialize)]
+struct AuthRequest {
+    data: AuthData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+struct AuthData {
+    account_name: String,
+    login_name: String,
+    authenticator: String,
+    browser_mode_redirect_port: u16,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthResponse {
+    data: AuthResponseData,
+    success: bool,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthResponseData {
+    sso_url: String,
+    proof_key: String,
+}
+
+#[derive(Deserialize)]
+struct TokenCallback {
+    #[serde(alias = "token", alias = "code")]
+    token: Option<String>,
+}
+
+pub async fn authenticate_via_browser(
+    http: &Client,
+    account: &str,
+    username: &str,
+) -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let (sso_url, proof_key) = get_sso_url(http, account, username, port).await?;
+
+    let token_state = Arc::new(Mutex::new(None::<String>));
+    let token = Arc::clone(&token_state);
+
+    let app = Router::new().route(
+        "/",
+        get(move |Query(params): Query<TokenCallback>| {
+            let state = token.clone();
+            async move {
+                params.token.map_or_else(
+                    || Html("Error: No token received"),
+                    |token| {
+                        *state.lock().unwrap() = Some(token);
+                        Html("Authentication successful. You can close this window now.")
+                    },
+                )
+            }
+        }),
+    );
+
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+    webbrowser::open(&sso_url)
+        .map_err(|e| Error::Communication(format!("Failed to open browser: {e}")))?;
+
+    let result = timeout(BROWSER_TIMEOUT, async {
+        loop {
+            if let Some(token) = &*token_state.lock().unwrap() {
+                return Ok(token.clone());
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+
+    server.abort();
+
+    match result {
+        Ok(Ok(token)) => validate_saml_response(http, account, username, &token, &proof_key).await,
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(Error::Communication(
+            "Browser authentication timeout".into(),
+        )),
+    }
+}
+
+async fn get_sso_url(
+    http: &Client,
+    account: &str,
+    username: &str,
+    port: u16,
+) -> Result<(String, String)> {
+    let url = format!("https://{account}.snowflakecomputing.com{SSO_URL_ENDPOINT}");
+
+    let response = http
+        .post(&url)
+        .json(&AuthRequest {
+            data: AuthData {
+                account_name: account.into(),
+                login_name: username.into(),
+                authenticator: "EXTERNALBROWSER".into(),
+                browser_mode_redirect_port: port,
+            },
+        })
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    if !status.is_success() {
+        return Err(Error::Communication(format!(
+            "Failed to get SSO URL: {body}"
+        )));
+    }
+
+    let resp: AuthResponse = serde_json::from_str(&body)
+        .map_err(|_| Error::Communication(format!("Invalid response: {body}")))?;
+
+    if !resp.success {
+        return Err(Error::Communication(
+            resp.message.unwrap_or_else(|| "Unknown error".into()),
+        ));
+    }
+
+    Ok((resp.data.sso_url, resp.data.proof_key))
+}
+
+async fn validate_saml_response(
+    http: &Client,
+    account: &str,
+    username: &str,
+    saml_response: &str,
+    proof_key: &str,
+) -> Result<String> {
+    let url = format!("https://{account}.snowflakecomputing.com/session/v1/login-request");
+    let login_data = serde_json::json!({
+        "data": {
+            "LOGIN_NAME": username,
+            "ACCOUNT_NAME": account,
+            "AUTHENTICATOR": "EXTERNALBROWSER",
+            "TOKEN": saml_response,
+            "PROOF_KEY": proof_key,
+        }
+    });
+
+    let response = http.post(&url).json(&login_data).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    if !status.is_success() {
+        return Err(Error::Communication(format!(
+            "Failed to validate SAML response: {body}"
+        )));
+    }
+
+    let resp: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|_| Error::Communication(format!("Invalid response: {body}")))?;
+
+    match (resp["success"].as_bool(), resp["data"]["token"].as_str()) {
+        (Some(true), Some(token)) => Ok(token.into()),
+        (Some(true), None) => Err(Error::Communication("No session token in response".into())),
+        _ => Err(Error::Communication(
+            resp["message"].as_str().unwrap_or("Unknown error").into(),
+        )),
+    }
+}

--- a/src/auth/external_browser.rs
+++ b/src/auth/external_browser.rs
@@ -1,8 +1,11 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
 use axum::{Router, extract::Query, response::Html, routing::get};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use tokio::{net::TcpListener, time::timeout};
 
 use crate::{Error, Result};
@@ -91,9 +94,7 @@ pub async fn authenticate_via_browser(
     match result {
         Ok(Ok(token)) => validate_saml_response(http, account, username, &token, &proof_key).await,
         Ok(Err(e)) => Err(e),
-        Err(_) => Err(Error::Communication(
-            "Browser authentication timeout".into(),
-        )),
+        Err(_) => Err(Error::Communication("Browser authentication timeout".into())),
     }
 }
 
@@ -121,18 +122,14 @@ async fn get_sso_url(
     let body = response.text().await?;
 
     if !status.is_success() {
-        return Err(Error::Communication(format!(
-            "Failed to get SSO URL: {body}"
-        )));
+        return Err(Error::Communication(format!("Failed to get SSO URL: {body}")));
     }
 
     let resp: AuthResponse = serde_json::from_str(&body)
         .map_err(|_| Error::Communication(format!("Invalid response: {body}")))?;
 
     if !resp.success {
-        return Err(Error::Communication(
-            resp.message.unwrap_or_else(|| "Unknown error".into()),
-        ));
+        return Err(Error::Communication(resp.message.unwrap_or_else(|| "Unknown error".into())));
     }
 
     Ok((resp.data.sso_url, resp.data.proof_key))
@@ -161,9 +158,7 @@ async fn validate_saml_response(
     let body = response.text().await?;
 
     if !status.is_success() {
-        return Err(Error::Communication(format!(
-            "Failed to validate SAML response: {body}"
-        )));
+        return Err(Error::Communication(format!("Failed to validate SAML response: {body}")));
     }
 
     let resp: serde_json::Value = serde_json::from_str(&body)
@@ -172,8 +167,6 @@ async fn validate_saml_response(
     match (resp["success"].as_bool(), resp["data"]["token"].as_str()) {
         (Some(true), Some(token)) => Ok(token.into()),
         (Some(true), None) => Err(Error::Communication("No session token in response".into())),
-        _ => Err(Error::Communication(
-            resp["message"].as_str().unwrap_or("Unknown error").into(),
-        )),
+        _ => Err(Error::Communication(resp["message"].as_str().unwrap_or("Unknown error").into())),
     }
 }

--- a/src/auth/key_pair.rs
+++ b/src/auth/key_pair.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey, LineEnding};
 use rsa::RsaPrivateKey;
@@ -36,10 +36,7 @@ pub(super) fn generate_jwt_from_key_pair(
     });
     let key = EncodingKey::from_rsa_pem(private.to_pkcs8_pem(LineEnding::LF)?.as_bytes())?;
     let jwt = jsonwebtoken::encode(
-        &Header {
-            alg: Algorithm::RS256,
-            ..Default::default()
-        },
+        &Header { alg: Algorithm::RS256, ..Default::default() },
         &payload,
         &key,
     )?;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,16 +1,15 @@
-mod key_pair;
 #[cfg(feature = "external-browser-authenticator")]
 mod external_browser;
+mod key_pair;
 
 use chrono::Utc;
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
-use crate::{Error, Result, SnowflakeAuthMethod, SnowflakeClientConfig};
-
-use self::key_pair::generate_jwt_from_key_pair;
 #[cfg(feature = "external-browser-authenticator")]
 use self::external_browser::authenticate_via_browser;
+use self::key_pair::generate_jwt_from_key_pair;
+use crate::{Error, Result, SnowflakeAuthMethod, SnowflakeClientConfig};
 
 /// Login to Snowflake and return a session token.
 pub(super) async fn login(
@@ -77,10 +76,7 @@ fn login_request_data(
             "PASSWORD": password,
             "ACCOUNT_NAME": config.account
         })),
-        SnowflakeAuthMethod::KeyPair {
-            encrypted_pem,
-            password,
-        } => {
+        SnowflakeAuthMethod::KeyPair { encrypted_pem, password } => {
             let jwt = generate_jwt_from_key_pair(
                 encrypted_pem,
                 password,
@@ -107,7 +103,7 @@ struct LoginResponse {
     token: String,
 }
 
-#[derive(serde:: Deserialize)]
+#[derive(serde::Deserialize)]
 struct Response {
     data: LoginResponse,
     message: Option<String>,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,4 +1,6 @@
 mod key_pair;
+#[cfg(feature = "external-browser-authenticator")]
+mod external_browser;
 
 use chrono::Utc;
 use reqwest::Client;
@@ -7,6 +9,8 @@ use serde_json::{json, Value};
 use crate::{Error, Result, SnowflakeAuthMethod, SnowflakeClientConfig};
 
 use self::key_pair::generate_jwt_from_key_pair;
+#[cfg(feature = "external-browser-authenticator")]
+use self::external_browser::authenticate_via_browser;
 
 /// Login to Snowflake and return a session token.
 pub(super) async fn login(
@@ -15,6 +19,11 @@ pub(super) async fn login(
     auth: &SnowflakeAuthMethod,
     config: &SnowflakeClientConfig,
 ) -> Result<String> {
+    #[cfg(feature = "external-browser-authenticator")]
+    if matches!(auth, SnowflakeAuthMethod::ExternalBrowser) {
+        return authenticate_via_browser(http, &config.account, username).await;
+    }
+
     let url = format!(
         "https://{account}.snowflakecomputing.com/session/v1/login-request",
         account = config.account
@@ -85,6 +94,10 @@ fn login_request_data(
                 "TOKEN": jwt,
                 "AUTHENTICATOR": "SNOWFLAKE_JWT"
             }))
+        }
+        #[cfg(feature = "external-browser-authenticator")]
+        SnowflakeAuthMethod::ExternalBrowser => {
+            unreachable!("External browser authentication is handled separately")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl SnowflakeClient {
     }
 
     pub fn with_proxy(self, host: &str, port: u16, username: &str, password: &str) -> Result<Self> {
-        let proxy = Proxy::all(format!("http://{}:{}", host, port).as_str())?
+        let proxy = Proxy::all(format!("http://{host}:{port}").as_str())?
             .basic_auth(username, password);
 
         let client = ClientBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,12 @@ mod session;
 
 use std::time::Duration;
 
+use auth::login;
 pub use error::{Error, Result};
 pub use query::QueryExecutor;
+use reqwest::{Client, ClientBuilder, Proxy};
 pub use row::{SnowflakeColumn, SnowflakeColumnType, SnowflakeDecode, SnowflakeRow};
 pub use session::SnowflakeSession;
-
-use auth::login;
-
-use reqwest::{Client, ClientBuilder, Proxy};
 
 #[derive(Clone)]
 pub struct SnowflakeClient {
@@ -99,8 +97,8 @@ impl SnowflakeClient {
     }
 
     pub fn with_proxy(self, host: &str, port: u16, username: &str, password: &str) -> Result<Self> {
-        let proxy = Proxy::all(format!("http://{host}:{port}").as_str())?
-            .basic_auth(username, password);
+        let proxy =
+            Proxy::all(format!("http://{host}:{port}").as_str())?.basic_auth(username, password);
 
         let client = ClientBuilder::new()
             .gzip(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@ pub enum SnowflakeAuthMethod {
         encrypted_pem: String,
         password: Vec<u8>,
     },
+    #[cfg(feature = "external-browser-authenticator")]
+    ExternalBrowser,
 }
 
 impl SnowflakeClient {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,17 +1,19 @@
-use std::time::{Duration, Instant};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use http::{
-    header::{ACCEPT, AUTHORIZATION},
     HeaderMap,
+    header::{ACCEPT, AUTHORIZATION},
 };
 use reqwest::Client;
-use tokio::sync::Mutex;
-use tokio::time::sleep;
+use tokio::{sync::Mutex, time::sleep};
 
-use crate::row::SnowflakeColumnType;
-use crate::SnowflakeSession;
-use crate::{chunk::download_chunk, Error, Result, SnowflakeRow};
+use crate::{
+    Error, Result, SnowflakeRow, SnowflakeSession, chunk::download_chunk, row::SnowflakeColumnType,
+};
 
 pub(super) const SESSION_EXPIRED: &str = "390112";
 pub(super) const QUERY_IN_PROGRESS_CODE: &str = "333333";
@@ -33,12 +35,7 @@ impl QueryExecutor {
         sess: &SnowflakeSession,
         request: Q,
     ) -> Result<Self> {
-        let SnowflakeSession {
-            http,
-            account,
-            session_token,
-            timeout,
-        } = sess;
+        let SnowflakeSession { http, account, session_token, timeout } = sess;
         let timeout = timeout.unwrap_or(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS));
 
         let request_id = uuid::Uuid::new_v4();
@@ -50,10 +47,7 @@ impl QueryExecutor {
         let response = http
             .post(url)
             .header(ACCEPT, "application/snowflake")
-            .header(
-                AUTHORIZATION,
-                format!(r#"Snowflake Token="{session_token}""#),
-            )
+            .header(AUTHORIZATION, format!(r#"Snowflake Token="{session_token}""#))
             .json(&request)
             .send()
             .await?;
@@ -225,10 +219,7 @@ async fn poll_for_async_results(
         let resp = http
             .get(url)
             .header(ACCEPT, "application/snowflake")
-            .header(
-                AUTHORIZATION,
-                format!(r#"Snowflake Token="{session_token}""#),
-            )
+            .header(AUTHORIZATION, format!(r#"Snowflake Token="{session_token}""#))
             .send()
             .await?;
 
@@ -258,9 +249,7 @@ pub struct QueryRequest {
 
 impl From<&str> for QueryRequest {
     fn from(sql_text: &str) -> Self {
-        Self {
-            sql_text: sql_text.to_string(),
-        }
+        Self { sql_text: sql_text.to_string() }
     }
 }
 impl From<&QueryRequest> for QueryRequest {

--- a/src/query.rs
+++ b/src/query.rs
@@ -52,7 +52,7 @@ impl QueryExecutor {
             .header(ACCEPT, "application/snowflake")
             .header(
                 AUTHORIZATION,
-                format!(r#"Snowflake Token="{}""#, session_token),
+                format!(r#"Snowflake Token="{session_token}""#),
             )
             .json(&request)
             .send()
@@ -220,14 +220,14 @@ async fn poll_for_async_results(
     let start = Instant::now();
     while start.elapsed() < timeout {
         sleep(Duration::from_secs(10)).await;
-        let url = format!("https://{account}.snowflakecomputing.com{}", result_url);
+        let url = format!("https://{account}.snowflakecomputing.com{result_url}");
 
         let resp = http
             .get(url)
             .header(ACCEPT, "application/snowflake")
             .header(
                 AUTHORIZATION,
-                format!(r#"Snowflake Token="{}""#, session_token),
+                format!(r#"Snowflake Token="{session_token}""#),
             )
             .send()
             .await?;

--- a/src/row.rs
+++ b/src/row.rs
@@ -77,11 +77,8 @@ impl SnowflakeRow {
         names.into_iter().map(|(name, _)| name.as_str()).collect()
     }
     pub fn column_types(&self) -> Vec<SnowflakeColumn> {
-        let mut names: Vec<(String, usize)> = self
-            .column_indices
-            .iter()
-            .map(|(k, v)| (k.clone(), *v))
-            .collect();
+        let mut names: Vec<(String, usize)> =
+            self.column_indices.iter().map(|(k, v)| (k.clone(), *v)).collect();
         names.sort_by_key(|(_, v)| *v);
         names
             .into_iter()
@@ -220,9 +217,7 @@ fn parse_timestamp_tz(s: &str, scale: i64) -> Result<NaiveDateTime> {
         .parse::<i64>()
         .map_err(|_| Error::Decode(format!("invalid timestamp_tz: {s}")))?;
     if !(0..=2880).contains(&tz) {
-        return Err(Error::Decode(format!(
-            "invalid timezone for timestamp_tz: {s}"
-        )));
+        return Err(Error::Decode(format!("invalid timezone for timestamp_tz: {s}")));
     }
     // subtract 24 hours from the timezone to map [0, 48] to [-24, 24]
     let min_addend = 1440 - tz;
@@ -307,7 +302,5 @@ impl TryGet for (&Option<String>, &SnowflakeColumnType) {
 }
 
 fn unwrap(value: &Option<String>) -> Result<&String> {
-    value
-        .as_ref()
-        .ok_or_else(|| Error::Decode("value is null".into()))
+    value.as_ref().ok_or_else(|| Error::Decode("value is null".into()))
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -63,7 +63,7 @@ impl SnowflakeRow {
         let idx = self
             .column_indices
             .get(&column_name.to_ascii_uppercase())
-            .ok_or_else(|| Error::Decode(format!("column not found: {}", column_name)))?;
+            .ok_or_else(|| Error::Decode(format!("column not found: {column_name}")))?;
         let ty = &self.column_types[*idx];
         (&self.row[*idx], ty).try_get()
     }
@@ -190,45 +190,44 @@ fn parse_timestamp_tz(s: &str, scale: i64) -> Result<NaiveDateTime> {
         let secs = frac_secs.trunc() as i64 / scale_factor as i64;
         let nsec = (frac_secs.fract() * 10_f64.powi(9 - scale as i32)) as u32;
         let dt = DateTime::from_timestamp(secs, nsec)
-            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {}", s)))?;
+            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {s}")))?;
         let dt = dt.naive_utc();
         return dt
             .checked_add_signed(TimeDelta::minutes(min_addend))
-            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp_tz: {}", s)));
+            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp_tz: {s}")));
     }
     // Assume the value is encoded as the other format (i.e. result version > 0)
     // once we cannot parse the string as a single float.
     let pair: Vec<_> = s.split_whitespace().collect();
     let v = pair
         .first()
-        .ok_or_else(|| Error::Decode(format!("invalid timestamp_tz: {}", s)))?;
+        .ok_or_else(|| Error::Decode(format!("invalid timestamp_tz: {s}")))?;
     let mut v = v
         .parse::<f64>()
-        .map_err(|_| Error::Decode(format!("invalid timestamp_tz: {}", s)))?;
+        .map_err(|_| Error::Decode(format!("invalid timestamp_tz: {s}")))?;
     let scale_factor = 10i32.pow(scale as u32);
     v *= scale_factor as f64;
     let secs = v.trunc() as i64 / scale_factor as i64;
     let nsec = (v.fract() * 10_f64.powi(9 - scale as i32)) as u32;
     let dt = DateTime::from_timestamp(secs, nsec)
-        .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {}", s)))?;
+        .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {s}")))?;
     let dt = dt.naive_utc();
 
     let tz = pair
         .get(1)
-        .ok_or_else(|| Error::Decode(format!("invalid timezone for timestamp_tz: {}", s)))?;
+        .ok_or_else(|| Error::Decode(format!("invalid timezone for timestamp_tz: {s}")))?;
     let tz = tz
         .parse::<i64>()
-        .map_err(|_| Error::Decode(format!("invalid timestamp_tz: {}", s)))?;
+        .map_err(|_| Error::Decode(format!("invalid timestamp_tz: {s}")))?;
     if !(0..=2880).contains(&tz) {
         return Err(Error::Decode(format!(
-            "invalid timezone for timestamp_tz: {}",
-            s
+            "invalid timezone for timestamp_tz: {s}"
         )));
     }
     // subtract 24 hours from the timezone to map [0, 48] to [-24, 24]
     let min_addend = 1440 - tz;
     dt.checked_add_signed(TimeDelta::minutes(min_addend))
-        .ok_or_else(|| Error::Decode(format!("Could not decode timestamp_tz: {}", s)))
+        .ok_or_else(|| Error::Decode(format!("Could not decode timestamp_tz: {s}")))
 }
 
 fn parse_timestamp_ntz_ltz(s: &str, scale: i64) -> Result<NaiveDateTime> {
@@ -238,10 +237,10 @@ fn parse_timestamp_ntz_ltz(s: &str, scale: i64) -> Result<NaiveDateTime> {
         let secs = v.trunc() as i64 / scale_factor as i64;
         let nsec = (v.fract() * 10_f64.powi(9 - scale as i32)) as u32;
         let dt = DateTime::from_timestamp(secs, nsec)
-            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {}", s)))?;
+            .ok_or_else(|| Error::Decode(format!("Could not decode timestamp: {s}")))?;
         return Ok(dt.naive_utc());
     }
-    Err(Error::Decode(format!("Could not decode timestamp: {}", s)))
+    Err(Error::Decode(format!("Could not decode timestamp: {s}")))
 }
 
 impl SnowflakeDecode for NaiveTime {
@@ -254,7 +253,7 @@ impl SnowflakeDecode for NaiveTime {
             let secs = (v.trunc() / scale_factor as f64) as u32;
             let nsec = (v.fract() * 10_f64.powi(9 - scale as i32)) as u32;
             let t = NaiveTime::from_num_seconds_from_midnight_opt(secs, nsec)
-                .ok_or_else(|| Error::Decode(format!("invalid time: {}", value)))?;
+                .ok_or_else(|| Error::Decode(format!("invalid time: {value}")))?;
             return Ok(t);
         }
         Err(Error::Decode(format!("'{value}' is not Time type")))

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use crate::{
-    query::{QueryExecutor, QueryRequest},
     Result, SnowflakeRow,
+    query::{QueryExecutor, QueryRequest},
 };
 
 pub struct SnowflakeSession {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,6 @@
 use snowflake_connector_rs::{Result, SnowflakeAuthMethod, SnowflakeClient, SnowflakeClientConfig};
 
+#[cfg(not(feature = "external-browser-authenticator"))]
 pub fn connect() -> Result<SnowflakeClient> {
     let username = std::env::var("SNOWFLAKE_USERNAME").expect("set SNOWFLAKE_USERNAME for testing");
     let password = std::env::var("SNOWFLAKE_PASSWORD").expect("set SNOWFLAKE_PASSWORD for testing");
@@ -13,6 +14,32 @@ pub fn connect() -> Result<SnowflakeClient> {
     let client = SnowflakeClient::new(
         &username,
         SnowflakeAuthMethod::Password(password),
+        SnowflakeClientConfig {
+            account,
+            warehouse,
+            database,
+            schema,
+            role,
+            timeout: None,
+        },
+    )?;
+
+    Ok(client)
+}
+
+#[cfg(feature = "external-browser-authenticator")]
+pub fn connect() -> Result<SnowflakeClient> {
+    let username = std::env::var("SNOWFLAKE_USERNAME").expect("set SNOWFLAKE_USERNAME for testing");
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").expect("set SNOWFLAKE_ACCOUNT for testing");
+
+    let role = std::env::var("SNOWFLAKE_ROLE").ok();
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok();
+    let database = std::env::var("SNOWFLAKE_DATABASE").ok();
+    let schema = std::env::var("SNOWFLAKE_SCHEMA").ok();
+
+    let client = SnowflakeClient::new(
+        &username,
+        SnowflakeAuthMethod::ExternalBrowser,
         SnowflakeClientConfig {
             account,
             warehouse,

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -22,6 +22,7 @@ async fn test_decode_naive_date() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "external-browser-authenticator"))]
 #[tokio::test]
 async fn test_basic_operations() -> Result<()> {
     // Connect to Snowflake

--- a/tests/test-basic-operations.rs
+++ b/tests/test-basic-operations.rs
@@ -33,10 +33,7 @@ async fn test_basic_operations() -> Result<()> {
     let query = "CREATE TEMPORARY TABLE example (id NUMBER, value STRING)";
     let rows = session.query(query).await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(
-        rows[0].get::<String>("STATUS")?,
-        "Table EXAMPLE successfully created."
-    );
+    assert_eq!(rows[0].get::<String>("STATUS")?, "Table EXAMPLE successfully created.");
 
     // Insert some data
     let query = "INSERT INTO example (id, value) VALUES (1, 'hello'), (2, 'world')";

--- a/tests/test-chunk.rs
+++ b/tests/test-chunk.rs
@@ -9,8 +9,7 @@ async fn test_download_chunked_results() -> Result<()> {
 
     // Act
     let session = client.create_session().await?;
-    let query =
-        "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
+    let query = "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
     let rows = session.query(query).await?;
 
     // Assert
@@ -21,22 +20,10 @@ async fn test_download_chunked_results() -> Result<()> {
     assert!(rows[0].column_names().contains(&"RAND"));
 
     let columns = rows[0].column_types();
-    assert_eq!(
-        columns[0]
-            .column_type()
-            .snowflake_type()
-            .to_ascii_uppercase(),
-        "FIXED"
-    );
+    assert_eq!(columns[0].column_type().snowflake_type().to_ascii_uppercase(), "FIXED");
     assert!(!columns[0].column_type().nullable());
     assert_eq!(columns[0].index(), 0);
-    assert_eq!(
-        columns[1]
-            .column_type()
-            .snowflake_type()
-            .to_ascii_uppercase(),
-        "TEXT"
-    );
+    assert_eq!(columns[1].column_type().snowflake_type().to_ascii_uppercase(), "TEXT");
     assert!(!columns[1].column_type().nullable());
     assert_eq!(columns[1].index(), 1);
 
@@ -50,8 +37,7 @@ async fn test_query_executor() -> Result<()> {
 
     // Act
     let session = client.create_session().await?;
-    let query =
-        "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
+    let query = "SELECT SEQ8() AS SEQ, RANDSTR(1000, RANDOM()) AS RAND FROM TABLE(GENERATOR(ROWCOUNT=>10000))";
 
     let executor = session.execute(query).await?;
     let mut rows = Vec::with_capacity(10000);

--- a/tests/test-decode.rs
+++ b/tests/test-decode.rs
@@ -18,10 +18,7 @@ async fn test_decode() -> Result<()> {
     )";
     let rows = session.query(query).await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(
-        rows[0].get::<String>("STATUS")?,
-        "Table EXAMPLE successfully created."
-    );
+    assert_eq!(rows[0].get::<String>("STATUS")?, "Table EXAMPLE successfully created.");
 
     // Insert some data
     let query = "INSERT INTO example (n, s, b, d, tm, ltz, ntz, tz) VALUES (

--- a/tests/test-decode.rs
+++ b/tests/test-decode.rs
@@ -3,6 +3,7 @@ mod common;
 #[cfg(not(feature = "external-browser-authenticator"))]
 use snowflake_connector_rs::Result;
 
+#[cfg(not(feature = "external-browser-authenticator"))]
 #[tokio::test]
 async fn test_decode() -> Result<()> {
     // Connect to Snowflake

--- a/tests/test-decode.rs
+++ b/tests/test-decode.rs
@@ -1,5 +1,6 @@
 mod common;
 
+#[cfg(not(feature = "external-browser-authenticator"))]
 use snowflake_connector_rs::Result;
 
 #[tokio::test]


### PR DESCRIPTION
This PR adds support for external browser authentication to the Snowflake connector, allowing users to authenticate via their web browser using SSO/SAML.

## Changes

- Added new `ExternalBrowser` variant to `SnowflakeAuthMethod` enum (behind `external-browser-authenticator` feature flag)
- Implemented browser-based authentication flow
- Updated dependencies to include required crates for web server and browser functionality
- Added example demonstrating external browser authentication usage
- Updated Rust edition to 2024 and added `rustfmt.toml` for consistent code formatting
- Modified tests to handle the external browser authentication feature

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update